### PR TITLE
Fix token masking for sufficiency (address #27)

### DIFF
--- a/ferret/evaluators/faithfulness_measures.py
+++ b/ferret/evaluators/faithfulness_measures.py
@@ -226,7 +226,9 @@ class AOPC_Sufficiency_Evaluation(BaseEvaluator):
             if removal_args["remove_tokens"]:
                 discrete_expl_th_token_ids = sample[id_top]
             else:
-                sample[id_top] = self.tokenizer.mask_token_id
+                mask_not_top = np.ones(sample.size, dtype=bool)
+                mask_not_top[id_top] = False
+                sample[mask_not_top] = self.tokenizer.mask_token_id
                 discrete_expl_th_token_ids = sample
             ##############################################
 


### PR DESCRIPTION
Fix token masking for sufficiency when removal_args["remove_tokens"] == False.
Address #27 

In the case of using the mask token for removal rather than removing tokens (i.e., when removal_args["remove_tokens"] == False) for sufficiency we mask the tokens not in the 'id_top' to preserve just the most important tokens.

