### PR TITLE
switch to pypi version of whisperx to avoid direct urls in deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ pydub = { version = "0.25.1", optional = true }
 audiomentations = { version = "0.34.1", optional = true }
 audiostretchy = { version = "1.3.5", optional = true }
 pyroomacoustics = { version = "0.7.3", optional = true }
-# WhisperX is not on PyPI: install from GitHub repo.
-whisperx = { git = "https://github.com/m-bain/whisperx.git", branch = "main", optional = true }
+whisperx = { version = "3.1.2", optional = true }
 
 [tool.poetry.extras]
 speech = [


### PR DESCRIPTION
As per the title says, and since [direct dependences are not allowed in public indexes such as PyPi](https://peps.python.org/pep-0440/#direct-references), we are switching to whisperx v3.1.2 released on pypi. 

Since we have no guarantees this was released by the official authors, we version lock it in our reqs. 

EDIT: linking this issue for reference: https://github.com/m-bain/whisperX/issues/700